### PR TITLE
Adding work dir for builds and fixing automatic patching

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ include: '.gitlab-ci.common.yml'
 ###################################################
 
 .image_template:
-  extends: [.docker_template]
+  extends: [.docker_template, .bp_tools_mixin]
   script:
     - echo "[CI] Building image ${CONTAINER_IMAGE}" | tee -a ${JOB_LOG}
     - >
@@ -29,7 +29,7 @@ include: '.gitlab-ci.common.yml'
       -t ${CONTAINER_IMAGE} >> ${JOB_LOG} 2>&1
 
 .tool_template:
-  extends: [.install_template]
+  extends: [.install_template, .bp_tools_mixin]
   variables:
     INSTALL_ROOT: "install-${DOCKER_PLATFORM}"
     WORK_ROOT: "work-${DOCKER_PLATFORM}"
@@ -49,7 +49,7 @@ include: '.gitlab-ci.common.yml'
     - make -C ${GIT_SRC_DIR} -j${CORES_PER_JOB} rebuild.${TOOL} >> ${JOB_LOG} 2>&1
 
 .publish_template:
-  extends: [.package_template]
+  extends: [.package_template, .bp_tools_mixin]
   variables:
     # Template variables
     PACKAGE_NAME: "tools-${DOCKER_PLATFORM}"
@@ -93,7 +93,7 @@ stages:
 #      - DOCKER_PLATFORM: $DOCKER_PLATFORM
 
 docker-image:
-  extends: [.image_template, .bp_tools_mixin]
+  extends: [.image_template]
   stage: image
   parallel:
     matrix:
@@ -101,7 +101,7 @@ docker-image:
   rules: !reference [.image_template, rules]
 
 install:
-  extends: [.tool_template, .bp_tools_mixin]
+  extends: [.tool_template]
   stage: build
   parallel:
     matrix:
@@ -113,7 +113,7 @@ install:
         TOOL: ["bsg_sv2v", "bsg_fakeram"]
 
 publish:
-  extends: [.publish_template, .bp_tools_mixin]
+  extends: [.publish_template]
   stage: publish
   parallel:
     matrix:

--- a/Makefile.common
+++ b/Makefile.common
@@ -88,14 +88,23 @@ endef
 # Makefile target templates
 #############################
 
-define bsg_tgt_patch_tag
+define bsg_tgt_build_tag
+	$(eval MAKEFLAGS := $(filter-out $(EXTRAMAKEFLAGS),$(MAKEFLAGS)))
 	$(eval name := $(1))
 	$(eval src_dir := $(2))
 	$(eval touch_dir := $(3))
 	$(eval patch_dir := $(4))
+	$(eval work_dir := $(5))
+	$(eval tag := $(6))
+	# patch targets
 	$(eval patch_tag := $(touch_dir)/$(name).patch.$(tag))
 	$(eval patch_target := patch.$(name))
 	$(eval repatch_target := repatch.$(name))
+	# build targets
+	$(eval build_tag := $(touch_dir)/$(name).build.$(tag))
+	$(eval build_target := build.$(name))
+	$(eval rebuild_target := rebuild.$(name))
+	$(eval internal_target := $(work_dir)/$(name)/.$(name)_build)
 $(patch_target): | $(patch_tag)
 $(repatch_target):
 	@rm -f $(touch_dir)/$(name).patch.*
@@ -106,8 +115,7 @@ $(repatch_target):
 	fi
 	@+$(MAKE) $(patch_tag)
 $(patch_tag):
-	$(eval src := $(shell basename $(src_dir)))
-	$(eval patch_root := $(patch_dir)/$(src))
+	$(eval patch_root := $(patch_dir)/$(if $(src_dir),$(shell basename $(src_dir)),$(name)))
 	$(eval patch_files := $(shell find $(patch_root) -name "*.patch" 2>/dev/null))
 	$(eval apply_patch := git apply --ignore-whitespace --ignore-space-change)
 	$(eval check_patch := $(apply_patch) --check --reverse)
@@ -127,46 +135,26 @@ $(patch_tag):
 		$(check_patch) $(p) --directory $(dir $(subst $(patch_dir)/,,$(p)));\
 	)
 	@touch $$@
-endef
-
-define bsg_tgt_build_tag
-	$(eval name := $(1))
-	$(eval src_dir := $(2))
-	$(eval touch_dir := $(3))
-	$(eval tag := $(5))
-	$(eval build_tag := $(touch_dir)/$(name).build.$(tag))
-	$(eval external_target := build.$(name))
-	$(eval rebuild_target := rebuild.$(name))
-	$(eval internal_target := $(src_dir)/.$(name)_build)
-	$(eval MAKEFLAGS := $(filter-out $(EXTRAMAKEFLAGS),$(MAKEFLAGS)))
-$(external_target): | $(build_tag)
+$(build_target): | $(build_tag)
 $(rebuild_target):
 	@rm -f $(touch_dir)/$(name).build.*
+	@rm -rf $(work_dir)/$(name)
 	@+$(MAKE) $(build_tag)
-$(build_tag):
+$(build_tag): | $(patch_tag)
+	@mkdir -p $(work_dir)/$(name)
 	@+$(MAKE) $(internal_target)
-	@echo "Build of $(name) successful; ignore errors"
 	@touch $$@
+$(internal_target): $(src_dir)
 endef
 
-define bsg_tgt_build_if_new
+define bsg_tgt_build_submodule
 	$(eval name := $(1))
 	$(eval src_dir := $(2))
 	$(eval touch_dir := $(3))
 	$(eval patch_dir := $(4))
-	$(eval tag := $(shell cd $(src_dir); git rev-parse HEAD))
-	$(eval $(call bsg_tgt_patch_tag,$(name),$(src_dir),$(touch_dir),$(patch_dir),$(tag)))
-	$(eval $(call bsg_tgt_build_tag,$(name),$(src_dir),$(touch_dir),$(patch_dir),$(tag)))
-endef
-
-define bsg_tgt_build_if_missing
-	$(eval name := $(1))
-	$(eval src_dir := $(2))
-	$(eval touch_dir := $(3))
-	$(eval patch_dir := $(4))
-	$(eval tag := any)
-	$(eval $(call bsg_tgt_patch_tag,$(name),$(src_dir),$(touch_dir),$(patch_dir),$(tag)))
-	$(eval $(call bsg_tgt_build_tag,$(name),$(src_dir),$(touch_dir),$(patch_dir),$(tag)))
+	$(eval work_dir := $(5))
+	$(eval tag := $(if $(src_dir),$(shell cd $(src_dir); git rev-parse HEAD),any))
+	$(eval $(call bsg_tgt_build_tag,$(name),$(src_dir),$(touch_dir),$(patch_dir),$(work_dir),$(tag)))
 endef
 
 #############################
@@ -236,6 +224,7 @@ endif
 ##########################################################
 ## Other tools
 ##########################################################
+AUTOCONF  ?= autoconf
 CAT       ?= cat
 CMAKE     ?= $(if $(shell which cmake3),cmake3,cmake)
 CD        ?= cd

--- a/mk/Makefile.tools
+++ b/mk/Makefile.tools
@@ -1,5 +1,5 @@
 
-$(eval $(call bsg_tgt_build_if_missing,boost,$(BP_WORK_DIR),$(BP_TOUCH_DIR),$(BP_PATCH_DIR)))
+$(eval $(call bsg_tgt_build_submodule,boost,,$(BP_TOUCH_DIR),$(BP_PATCH_DIR),$(BP_WORK_DIR)))
 %/.boost_build:
 	@$(eval BOOST_VERSION := 1.82.0)
 	@$(eval BOOST := boost_$(subst .,_,$(BOOST_VERSION)))
@@ -9,82 +9,69 @@ $(eval $(call bsg_tgt_build_if_missing,boost,$(BP_WORK_DIR),$(BP_TOUCH_DIR),$(BP
 	@$(eval CONFIG_H := $(shell python -c "import sysconfig; print(sysconfig.get_config_h_filename());"))
 	@$(eval CONFIG_DIR := $(dir $(CONFIG_H)))
 	@$(eval export CPLUS_INCLUDE_PATH := $(CONFIG_DIR):$(CPLUS_INCLUDE_PATH))
-	@$(CD) $(@D); \
-		$(WGET) -qO- $(BOOST_DOWNLOAD) | $(TAR) xzv
-	@$(CD) $(@D)/$(BOOST); \
-		./bootstrap.sh --prefix=$(BP_INSTALL_DIR)
-	@$(CD) $(@D)/$(BOOST); \
-		./b2 --prefix=$(BP_INSTALL_DIR) \
-			toolset=gcc \
-			install
+	@$(WGET) -qO- $(BOOST_DOWNLOAD) | $(TAR) xzv -C $(@D) --strip-components=1
+	@$(CD) $(@D); ./bootstrap.sh --prefix=$(BP_INSTALL_DIR)
+	@$(CD) $(@D); ./b2 --prefix=$(BP_INSTALL_DIR) toolset=gcc install
 
-$(eval $(call bsg_tgt_build_if_new,axe,$(BP_AXE_DIR),$(BP_TOUCH_DIR),$(BP_PATCH_DIR)))
+$(eval $(call bsg_tgt_build_submodule,axe,$(BP_AXE_DIR),$(BP_TOUCH_DIR),$(BP_PATCH_DIR),$(BP_WORK_DIR)))
 %/.axe_build:
-	@$(CD) $(@D)/src; ./make.sh
-	@$(CP) $(@D)/src/axe $(BP_BIN_DIR)
+	@$(CD) $</src; ./make.sh
+	@$(CP) $</src/axe $(BP_BIN_DIR)
 
-$(eval $(call bsg_tgt_build_if_new,bsg_fakeram,$(BP_FAKERAM_DIR),$(BP_TOUCH_DIR),$(BP_PATCH_DIR)))
+$(eval $(call bsg_tgt_build_submodule,bsg_fakeram,$(BP_FAKERAM_DIR),$(BP_TOUCH_DIR),$(BP_PATCH_DIR),$(BP_WORK_DIR)))
 %/.bsg_fakeram_build:
-	@$(MAKE) -j1 -C $(@D) tools
+	@$(MAKE) -j1 -C $< tools
 
-$(eval $(call bsg_tgt_build_if_new,bsg_sv2v,$(BP_SV2V_DIR),$(BP_TOUCH_DIR),$(BP_PATCH_DIR)))
+$(eval $(call bsg_tgt_build_submodule,bsg_sv2v,$(BP_SV2V_DIR),$(BP_TOUCH_DIR),$(BP_PATCH_DIR),$(BP_WORK_DIR)))
 %/.bsg_sv2v_build:
 	@$(eval PYVERILOG_URL := https://github.com/PyHDI/Pyverilog.git)
 	@$(eval PYVERILOG_VER := 1.1.3)
 	@$(eval PYVERILOG_DIR := $(@D)/Pyverilog)
 	@$(RMRF) $(PYVERILOG_DIR)
 	@$(GIT) clone -b $(PYVERILOG_VER) $(PYVERILOG_URL) $(PYVERILOG_DIR)
-	@$(CD) $(PYVERILOG_DIR); $(GIT) apply $(@D)/patches/pyverilog_add_wirelist_reglist.patch
-	@$(CD) $(PYVERILOG_DIR); $(GIT) apply $(@D)/patches/pyverilog_sensitivity_comp.patch
-	@$(CD) $(PYVERILOG_DIR); $(PYTHON) setup.py install
+	@$(GIT) -C $(PYVERILOG_DIR) apply $</patches/pyverilog_add_wirelist_reglist.patch
+	@$(GIT) -C $(PYVERILOG_DIR) apply $</patches/pyverilog_sensitivity_comp.patch
+	@$(PYTHON) $(PYVERILOG_DIR)/setup.py install
 
-$(eval $(call bsg_tgt_build_if_new,dromajo,$(BP_DROMAJO_DIR),$(BP_TOUCH_DIR),$(BP_PATCH_DIR)))
+$(eval $(call bsg_tgt_build_submodule,dromajo,$(BP_DROMAJO_DIR),$(BP_TOUCH_DIR),$(BP_PATCH_DIR),$(BP_WORK_DIR)))
 %/.dromajo_build:
-	@$(eval SOURCE_DIR := $(@D))
-	@$(eval BUILD_DIR := $(@D)/build)
-	@$(MKDIR) -p $(BUILD_DIR)
-	@$(CMAKE) -S $(SOURCE_DIR) -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=Release
-	@$(MAKE) -C $(BUILD_DIR)
-	@$(CP) $(BUILD_DIR)/dromajo $(BP_BIN_DIR)
-	@$(CP) $(BUILD_DIR)/libdromajo_cosim.a $(BP_LIB_DIR)
-	@$(CP) $(SOURCE_DIR)/include/* $(BP_INCLUDE_DIR)
-
-$(eval $(call bsg_tgt_build_if_new,spike,$(BP_SPIKE_DIR),$(BP_TOUCH_DIR),$(BP_PATCH_DIR)))
-%/.spike_build:
-	@$(CD) $(@D); \
-		./configure --prefix=$(BP_INSTALL_DIR) \
-		--without-boost --without-boost-asio --without-boost-regex; \
-		$(MAKE) && $(MAKE) install
-
-$(eval $(call bsg_tgt_build_if_new,surelog,$(BP_SURELOG_DIR),$(BP_TOUCH_DIR),$(BP_PATCH_DIR)))
-%/.surelog_build:
-	@$(eval BUILD_DIR := $(@D)/build)
-	@$(MKDIR) -p $(BUILD_DIR)
-	@$(CMAKE) -S $(@D) -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(BP_INSTALL_DIR)
-	@$(CD) $(BUILD_DIR); \
-		$(MAKE) && $(MAKE) install
-
-$(eval $(call bsg_tgt_build_if_new,verilator,$(BP_VERILATOR_DIR),$(BP_TOUCH_DIR),$(BP_PATCH_DIR)))
-%/.verilator_build:
-	@$(CD) $(@D); \
-		autoconf; \
-		./configure --prefix=$(BP_INSTALL_DIR);
+	@$(CMAKE) -S $< -B $(@D) -DCMAKE_BUILD_TYPE=Release
 	@$(MAKE) -C $(@D)
-	@$(MAKE) -C $(@D) install
-	@$(CP) $(@D)/include/vltstd/svdpi.h $(BP_INCLUDE_DIR)
+	@$(CP) $(@D)/dromajo $(BP_BIN_DIR)
+	@$(CP) $(@D)/libdromajo_cosim.a $(BP_LIB_DIR)
+	@$(CP) $</include/* $(BP_INCLUDE_DIR)
 
-$(eval $(call bsg_tgt_build_if_new,yosys,$(BP_YOSYS_DIR),$(BP_TOUCH_DIR),$(BP_PATCH_DIR)))
+$(eval $(call bsg_tgt_build_submodule,spike,$(BP_SPIKE_DIR),$(BP_TOUCH_DIR),$(BP_PATCH_DIR),$(BP_WORK_DIR)))
+%/.spike_build:
+	@$(CD) $(@D); $</configure --prefix=$(BP_INSTALL_DIR) --srcdir=$< \
+		--without-boost --without-boost-asio --without-boost-regex
+	@$(MAKE) -C $(@D) install
+
+$(eval $(call bsg_tgt_build_submodule,surelog,$(BP_SURELOG_DIR),$(BP_TOUCH_DIR),$(BP_PATCH_DIR),$(BP_WORK_DIR)))
+%/.surelog_build:
+	@$(CMAKE) -S $< -B $(@D) -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(BP_INSTALL_DIR)
+	@$(MAKE) -C $(@D) install
+
+$(eval $(call bsg_tgt_build_submodule,verilator,$(BP_VERILATOR_DIR),$(BP_TOUCH_DIR),$(BP_PATCH_DIR),$(BP_WORK_DIR)))
+%/.verilator_build:
+	@$(CD) $(@D); $(AUTOCONF) -o ./configure $</configure.ac
+	@$(CD) $(@D); ./configure --prefix=$(BP_INSTALL_DIR) --srcdir=$<
+	@$(MAKE) -C $(@D) all
+	@$(MAKE) -C $(@D) install
+	@$(MAKE) -C $(@D) install-all
+
+$(eval $(call bsg_tgt_build_submodule,yosys,$(BP_YOSYS_DIR),$(BP_TOUCH_DIR),$(BP_PATCH_DIR),$(BP_WORK_DIR)))
 %/.yosys_build:
 	@$(eval export PREFIX := $(BP_INSTALL_DIR))
-	@$(CD) $(@D); \
-		$(MAKE) config-gcc && $(MAKE) && $(MAKE) install
+	@$(MAKE) -C $< config-gcc
+	@$(MAKE) -C $< install
 
-$(eval $(call bsg_tgt_build_if_new,yslang,$(BP_YSLANG_DIR),$(BP_TOUCH_DIR),$(BP_PATCH_DIR)))
-%/.yslang_build: build.yosys
+$(eval $(call bsg_tgt_build_submodule,yslang,$(BP_YSLANG_DIR),$(BP_TOUCH_DIR),$(BP_PATCH_DIR),$(BP_WORK_DIR)))
+%/.yslang_build:
 	@$(eval YOSYS_PLUGIN_DIR := $(BP_INSTALL_DIR)/share/yosys/plugins)
 	@$(eval export YOSYS_PREFIX := $(BP_INSTALL_DIR)/bin/)
+	@$(MAKE) build.yosys
+	@$(MAKE) -C $<
 	@$(MKDIR) -p $(YOSYS_PLUGIN_DIR)
-	@$(CD) $(@D); \
-		$(MAKE) build; \
-		$(CP) build/*.so $(YOSYS_PLUGIN_DIR)
+	@$(CP) $</build/*.so $(YOSYS_PLUGIN_DIR)
 


### PR DESCRIPTION
This PR makes it easier to parallelize builds by using an intermediate work directory. There was also a bug where patching wasn't guaranteed to happen (whoops). Result is that build targets now have both a src_dir and work_dir available to play around with